### PR TITLE
IS-1801: Legger til innstilling om stans vurderingstatus

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/dto/Aktivitetsplikt.kt
+++ b/src/main/kotlin/no/nav/syfo/api/dto/Aktivitetsplikt.kt
@@ -5,7 +5,17 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 enum class AktivitetspliktStatus {
-    NY, NY_VURDERING, AVVENT, UNNTAK, OPPFYLT, AUTOMATISK_OPPFYLT, FORHANDSVARSEL, IKKE_OPPFYLT, IKKE_AKTUELL, LUKKET
+    NY,
+    NY_VURDERING,
+    AVVENT,
+    UNNTAK,
+    OPPFYLT,
+    AUTOMATISK_OPPFYLT,
+    FORHANDSVARSEL,
+    IKKE_OPPFYLT,
+    INNSTILLING_OM_STANS,
+    IKKE_AKTUELL,
+    LUKKET
 }
 
 data class Aktivitetsplikt(

--- a/src/main/kotlin/no/nav/syfo/kafka/consumer/domain/KAktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumer/domain/KAktivitetskravVarsel.kt
@@ -39,9 +39,7 @@ data class KAktivitetskravVarsel(
     val document: List<DocumentComponentDTO>,
     val type: String
 ) : Serializable, VarselbusEvent {
-    companion object {
-        private const val serialVersionUID = 1L
-    }
+
     override fun personIdent() = personIdent
 
     override fun varselData(): VarselData = VarselData(
@@ -55,11 +53,11 @@ data class KAktivitetskravVarsel(
             extendMicrofrontendDuration = false
         )
     )
+    companion object {
+        private const val serialVersionUID = 1L
+    }
 }
 
 enum class AktivitetskravVarselType {
     FORHANDSVARSEL_STANS_AV_SYKEPENGER,
-    UNNTAK,
-    OPPFYLT,
-    IKKE_AKTUELL
 }

--- a/src/main/kotlin/no/nav/syfo/kafka/consumer/domain/KAktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumer/domain/KAktivitetskravVurdering.kt
@@ -21,9 +21,7 @@ data class KAktivitetskravVurdering(
     val sistVurdert: OffsetDateTime?,
     val frist: LocalDate?
 ) : Serializable, VarselbusEvent {
-    companion object {
-        private const val serialVersionUID = 1L
-    }
+
     override fun personIdent() = personIdent
 
     override fun varselData() = VarselData(
@@ -33,13 +31,17 @@ data class KAktivitetskravVurdering(
             extendMicrofrontendDuration = shouldExtendMicrofrontendDuration(this)
         )
     )
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
 }
 
 private fun shouldEnableMikrofrontend(vurdering: KAktivitetskravVurdering) =
     when (vurdering.status) {
         AktivitetspliktStatus.NY.name,
         AktivitetspliktStatus.NY_VURDERING.name,
-        AktivitetspliktStatus.FORHANDSVARSEL.name
+        AktivitetspliktStatus.FORHANDSVARSEL.name,
         -> true
         else -> false
     }


### PR DESCRIPTION
Erstatter [denne PR'en](https://github.com/navikt/aktivitetskrav-backend/pull/102). Se denne for tidligere kommentarer

Se [tilhørende PR](https://github.com/navikt/aktivitetskrav-frontend/pull/713) i `aktivitetskrav-backend`