### PR TITLE
Adding back dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gradle
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '14:30'
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Created from github repo settings, as suggested as fix for others with similar problem