### PR TITLE
fix(api): allow aktivitetskrav-microfrontend access

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -50,7 +50,7 @@ spec:
       rules:
         - application: esyfo-proxy
         - application: aktivitetskrav-frontend
-        - application: esyfo-microfrontends
+        - application: aktivitetskrav-microfrontend
   gcp:
     sqlInstances:
       - type: POSTGRES_17
@@ -77,3 +77,5 @@ spec:
       value: dev-gcp:team-esyfo:esyfo-proxy
     - name: AKTIVITETSKRAV_FRONTEND_CLIENT_ID
       value: dev-gcp:team-esyfo:aktivitetskrav-frontend
+    - name: AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID
+      value: dev-gcp:team-esyfo:aktivitetskrav-microfrontend

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -51,7 +51,7 @@ spec:
       rules:
         - application: esyfo-proxy
         - application: aktivitetskrav-frontend
-        - application: esyfo-microfrontends
+        - application: aktivitetskrav-microfrontend
   gcp:
     sqlInstances:
       - type: POSTGRES_17
@@ -78,3 +78,5 @@ spec:
       value: prod-gcp:team-esyfo:esyfo-proxy
     - name: AKTIVITETSKRAV_FRONTEND_CLIENT_ID
       value: prod-gcp:team-esyfo:aktivitetskrav-frontend
+    - name: AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID
+      value: prod-gcp:team-esyfo:aktivitetskrav-microfrontend

--- a/src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt
@@ -28,6 +28,8 @@ class AktivitetspliktApi(
     val esyfoProxyClientId: String,
     @param:Value("\${AKTIVITETSKRAV_FRONTEND_CLIENT_ID}")
     val aktivitetskravFrontendClientId: String,
+    @param:Value("\${AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID}")
+    val aktivitetskravMicroFrontendClientId: String,
     val tokenValidationContextHolder: TokenValidationContextHolder,
     val aktivitetskravService: AktivitetskravService
 ) {
@@ -38,7 +40,7 @@ class AktivitetspliktApi(
     fun init() {
         tokenValidator = TokenValidator(
             tokenValidationContextHolder,
-            setOf(esyfoProxyClientId, aktivitetskravFrontendClientId)
+            setOf(esyfoProxyClientId, aktivitetskravFrontendClientId, aktivitetskravMicroFrontendClientId)
         )
     }
 


### PR DESCRIPTION
## Beskrivelse

Gir aktivitetskrav-microfrontend tilgang til API-et ved å oppdatere tillatt client ID i tokenvalideringen og NAIS-konfigurasjonen.

## Endringer

- `src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt`: inkluderer client ID for aktivitetskrav-microfrontend i tillatte kallere
- `nais/nais-dev.yaml`: bytter inbound-tilgang til aktivitetskrav-microfrontend og legger til tilhørende client ID
- `nais/nais-prod.yaml`: bytter inbound-tilgang til aktivitetskrav-microfrontend og legger til tilhørende client ID

## Issue

Ingen koblet issue.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)
