### PR TITLE
refactor(auth): remove esyfo-proxy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Aktivitetskrav-backend er en backend-tjeneste som håndterer **aktivitetskrav** 
 
 - **Konsumerer Kafka-events** fra `teamsykefravr` (vurderinger og varsler om aktivitetskrav)
 - **Lagrer data** i PostgreSQL (vurderinger med status, frister og begrunnelser, samt varsler med dokumentkomponenter)
-- **Eksponerer REST API** (beskyttet med TokenX) slik at sykmeldte kan se sin aktivitetsplikt-status via `esyfo-proxy`
+- **Eksponerer REST API** (beskyttet med TokenX) slik at sykmeldte kan se sin aktivitetsplikt-status via `aktivitetskrav-frontend` og `aktivitetskrav-microfrontend`
 - **Produserer events** til `team-esyfo.varselbus` for å vise varsler/dokumenter i brukerens mikrofrontend
 
 Mulige statuser er definert i [`AktivitetspliktStatus`](src/main/kotlin/no/nav/syfo/api/dto/Aktivitetsplikt.kt).
@@ -32,13 +32,15 @@ flowchart LR
         G[Kafka Producer]
     end
 
-    H[esyfo-proxy]
+    H[aktivitetskrav-frontend]
+    I[aktivitetskrav-microfrontend]
 
     A -->|vurdering| D
     B -->|varsel| D
     D --> E
     E --> F
-    F -->|TokenX| H
+    H -->|TokenX| F
+    I -->|TokenX| F
     D --> G
     G -->|SM_AKTIVITETSPLIKT| C
 ```
@@ -51,7 +53,7 @@ flowchart LR
 | `POST` | `/api/v1/aktivitetsplikt/les` | Marker aktivitetskrav som lest |
 | `GET` | `/api/v1/aktivitetsplikt/historikk` | Hent historikk for aktivitetskrav |
 
-Alle endepunkter krever TokenX-autentisering og er kun tilgjengelig via `esyfo-proxy`.
+Alle endepunkter krever TokenX-autentisering og er tilgjengelige for `aktivitetskrav-frontend` og `aktivitetskrav-microfrontend`.
 
 ## Utvikling
 

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -48,7 +48,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: esyfo-proxy
         - application: aktivitetskrav-frontend
         - application: aktivitetskrav-microfrontend
   gcp:
@@ -73,8 +72,6 @@ spec:
           - name: cloudsql.logical_decoding
             value: "on"
   env:
-    - name: ESYFO_PROXY_CLIENT_ID
-      value: dev-gcp:team-esyfo:esyfo-proxy
     - name: AKTIVITETSKRAV_FRONTEND_CLIENT_ID
       value: dev-gcp:team-esyfo:aktivitetskrav-frontend
     - name: AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -49,7 +49,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: esyfo-proxy
         - application: aktivitetskrav-frontend
         - application: aktivitetskrav-microfrontend
   gcp:
@@ -74,8 +73,6 @@ spec:
           - name: cloudsql.logical_decoding
             value: "on"
   env:
-    - name: ESYFO_PROXY_CLIENT_ID
-      value: prod-gcp:team-esyfo:esyfo-proxy
     - name: AKTIVITETSKRAV_FRONTEND_CLIENT_ID
       value: prod-gcp:team-esyfo:aktivitetskrav-frontend
     - name: AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID

--- a/src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt
@@ -24,8 +24,6 @@ import org.springframework.web.bind.annotation.ResponseBody
 @Controller
 @RequestMapping("/api/v1")
 class AktivitetspliktApi(
-    @param:Value("\${ESYFO_PROXY_CLIENT_ID}")
-    val esyfoProxyClientId: String,
     @param:Value("\${AKTIVITETSKRAV_FRONTEND_CLIENT_ID}")
     val aktivitetskravFrontendClientId: String,
     @param:Value("\${AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID}")
@@ -40,7 +38,7 @@ class AktivitetspliktApi(
     fun init() {
         tokenValidator = TokenValidator(
             tokenValidationContextHolder,
-            setOf(esyfoProxyClientId, aktivitetskravFrontendClientId, aktivitetskravMicroFrontendClientId)
+            setOf(aktivitetskravFrontendClientId, aktivitetskravMicroFrontendClientId)
         )
     }
 

--- a/src/test/kotlin/no/nav/syfo/TokenValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/TokenValidatorTest.kt
@@ -16,22 +16,11 @@ class TokenValidatorTest {
     private val jwtTokenClaims = mockk<JwtTokenClaims>()
 
     @Test
-    fun `should accept token with first expected client id`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:esyfo-proxy", "dev-gcp:team-esyfo:aktivitetskrav-frontend")
-        val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
-
-        every { tokenValidationContextHolder.getTokenValidationContext() } returns tokenValidationContext
-        every { tokenValidationContext.getClaims("tokenx") } returns jwtTokenClaims
-        every { jwtTokenClaims.getStringClaim("client_id") } returns "dev-gcp:team-esyfo:esyfo-proxy"
-
-        val claims = tokenValidator.validerTokenXClaims()
-
-        claims shouldBe jwtTokenClaims
-    }
-
-    @Test
-    fun `should accept token with second expected client id`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:esyfo-proxy", "dev-gcp:team-esyfo:aktivitetskrav-frontend")
+    fun `should accept token with aktivitetskrav frontend client id`() {
+        val expectedClientIds = setOf(
+            "dev-gcp:team-esyfo:aktivitetskrav-frontend",
+            "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+        )
         val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
 
         every { tokenValidationContextHolder.getTokenValidationContext() } returns tokenValidationContext
@@ -44,8 +33,28 @@ class TokenValidatorTest {
     }
 
     @Test
+    fun `should accept token with aktivitetskrav microfrontend client id`() {
+        val expectedClientIds = setOf(
+            "dev-gcp:team-esyfo:aktivitetskrav-frontend",
+            "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+        )
+        val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
+
+        every { tokenValidationContextHolder.getTokenValidationContext() } returns tokenValidationContext
+        every { tokenValidationContext.getClaims("tokenx") } returns jwtTokenClaims
+        every { jwtTokenClaims.getStringClaim("client_id") } returns "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+
+        val claims = tokenValidator.validerTokenXClaims()
+
+        claims shouldBe jwtTokenClaims
+    }
+
+    @Test
     fun `should reject token with unexpected client id`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:esyfo-proxy", "dev-gcp:team-esyfo:aktivitetskrav-frontend")
+        val expectedClientIds = setOf(
+            "dev-gcp:team-esyfo:aktivitetskrav-frontend",
+            "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+        )
         val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
 
         every { tokenValidationContextHolder.getTokenValidationContext() } returns tokenValidationContext
@@ -61,7 +70,10 @@ class TokenValidatorTest {
 
     @Test
     fun `should reject token with null client_id claim`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:esyfo-proxy", "dev-gcp:team-esyfo:aktivitetskrav-frontend")
+        val expectedClientIds = setOf(
+            "dev-gcp:team-esyfo:aktivitetskrav-frontend",
+            "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+        )
         val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
 
         every { tokenValidationContextHolder.getTokenValidationContext() } returns tokenValidationContext
@@ -75,7 +87,7 @@ class TokenValidatorTest {
 
     @Test
     fun `should extract fnr from idporten tokenx claims`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:esyfo-proxy")
+        val expectedClientIds = setOf("dev-gcp:team-esyfo:aktivitetskrav-frontend")
         val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
         val expectedFnr = "12345678910"
 

--- a/src/test/kotlin/no/nav/syfo/TokenValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/TokenValidatorTest.kt
@@ -87,7 +87,10 @@ class TokenValidatorTest {
 
     @Test
     fun `should extract fnr from idporten tokenx claims`() {
-        val expectedClientIds = setOf("dev-gcp:team-esyfo:aktivitetskrav-frontend")
+        val expectedClientIds = setOf(
+            "dev-gcp:team-esyfo:aktivitetskrav-frontend",
+            "dev-gcp:team-esyfo:aktivitetskrav-microfrontend"
+        )
         val tokenValidator = TokenValidator(tokenValidationContextHolder, expectedClientIds)
         val expectedFnr = "12345678910"
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,8 +5,6 @@ KAFKA_KEYSTORE_PATH: ""
 
 NAIS_CLUSTER_NAME: test
 
-ESYFO_PROXY_CLIENT_ID: "client-id"
-
 spring:
   profiles:
     active: test
@@ -32,7 +30,8 @@ spring:
     enabled: true
     path: '/h2'
 
-DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID: frontend-client-id
+AKTIVITETSKRAV_FRONTEND_CLIENT_ID: dev-gcp:team-esyfo:aktivitetskrav-frontend
+AKTIVITETSKRAV_MICRO_FRONTEND_CLIENT_ID: dev-gcp:team-esyfo:aktivitetskrav-microfrontend
 
 management:
   endpoint.prometheus.enabled: true


### PR DESCRIPTION
## Beskrivelse

Fjerner `esyfo-proxy` som innpass til `aktivitetskrav-backend` og rydder opp i auth-oppsett, NAIS-manifester, tester og dokumentasjon slik at kun `aktivitetskrav-frontend` og `aktivitetskrav-microfrontend` gjenstar som klienter.

## Endringer

- `src/main/kotlin/no/nav/syfo/api/AktivitetspliktApi.kt`: fjernet `ESYFO_PROXY_CLIENT_ID` fra runtime-auth
- `src/test/resources/application.yaml`: oppdatert testkonfig til gjenværende klienter
- `src/test/kotlin/no/nav/syfo/TokenValidatorTest.kt`: oppdatert eksisterende tester til frontend/microfrontend
- `nais/nais-dev.yaml`: fjernet inbound-regel og env-var for `esyfo-proxy`
- `nais/nais-prod.yaml`: fjernet inbound-regel og env-var for `esyfo-proxy`
- `README.md`: oppdatert tilgangsmodell og diagram uten `esyfo-proxy`

## Issue

Closes #200

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
