### PR TITLE
chore(build): bump Java to 25 LTS

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,7 +8,7 @@ on:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:
@@ -23,4 +23,4 @@ jobs:
     secrets: inherit
     with:
       app: aktivitetskrav-backend
-      java-version: "21"
+      java-version: "25"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"
 WORKDIR /app

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,6 @@ java {
 kotlin {
     jvmToolchain(25)
 }
-
-java.sourceCompatibility = JavaVersion.VERSION_25
-
 ext["okhttp3.version"] = "4.11.0"
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 group = "no.nav.syfo"
 version = "1.0.0"
 description = "aktivitetskrav-backend"
-java.sourceCompatibility = JavaVersion.VERSION_21
+java.sourceCompatibility = JavaVersion.VERSION_25
 
 ext["okhttp3.version"] = "4.11.0"
 
@@ -83,7 +83,7 @@ tasks {
     withType<KotlinCompile> {
         compilerOptions {
             freeCompilerArgs.set(listOf("-Xjsr305=strict"))
-            jvmTarget.set(JvmTarget.JVM_21)
+            jvmTarget.set(JvmTarget.JVM_25)
             if (System.getenv("CI") == "true") {
                 compilerOptions.allWarningsAsErrors.set(true)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
     id("org.springframework.boot") version "4.1.0"
@@ -12,6 +13,17 @@ plugins {
 group = "no.nav.syfo"
 version = "1.0.0"
 description = "aktivitetskrav-backend"
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
 java.sourceCompatibility = JavaVersion.VERSION_25
 
 ext["okhttp3.version"] = "4.11.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
     id("org.springframework.boot") version "4.1.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-java = "21"
+java = "25"
 
 [tasks.build]
 description = "Build the project"


### PR DESCRIPTION
## Beskrivelse

Oppgraderer prosjektet til Java 25 LTS og sørger for at Gradle faktisk bruker Java 25 ved bygging og kjøring av tester.

## Endringer

- `build.gradle.kts`: oppdatert Kotlin/Java target til 25 og lagt til Gradle toolchain for Java 25
- `Dockerfile`: oppdatert base image til `openjdk-25`
- `.github/workflows/build-and-deploy.yaml`: oppdatert `java-version` til `25`
- `mise.toml`: oppdatert lokal Java-versjon til `25`

## Issue

Closes #234
Del av epic: navikt/team-esyfo#143

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)